### PR TITLE
feat: 즐겨찾기 상태 localstorage 저장

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,10 @@
     "react": "^18.2.0",
     "react-apexcharts": "^1.4.0",
     "react-dom": "^18.2.0",
-    "recoil": "^0.7.6",
-    "web-vitals": "^2.1.4",
-    "zod": "^3.21.4"
+    "zod": "^3.21.4",
+    "recoil": "^0.7.7",
+    "recoil-persist": "^4.2.0",
+    "web-vitals": "^2.1.4"
   },
   "devDependencies": {
     "@emotion/babel-preset-css-prop": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -45,10 +45,9 @@
     "react": "^18.2.0",
     "react-apexcharts": "^1.4.0",
     "react-dom": "^18.2.0",
-    "zod": "^3.21.4",
     "recoil": "^0.7.7",
-    "recoil-persist": "^4.2.0",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@emotion/babel-preset-css-prop": "^11.10.0",

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -10,13 +10,13 @@ export const candleState = atom<CandleType>({
   default: 'minute',
 });
 
-export const favoriteListState = atom<Market[]>({
-  key: 'favoriteListState',
+export const favoriteCoinListState = atom<Market[]>({
+  key: 'favoriteCoinListState',
   default: [],
-  effects: [storageEffect('favoriteListState', 'localStorage')],
+  effects: [storageEffect('favoriteCoinListState', 'localStorage')],
 });
 
-export const targetState = atom<Market[]>({
-  key: 'targetState',
+export const selectedCoinState = atom<Market[]>({
+  key: 'selectedCoinState',
   default: [],
 });

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -15,3 +15,8 @@ export const favoriteListState = atom<Market[]>({
   default: [],
   effects: [storageEffect('favoriteListState', 'localStorage')],
 });
+
+export const targetState = atom<Market[]>({
+  key: 'targetState',
+  default: [],
+});

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -3,6 +3,8 @@ import {storageEffect} from '@/effects';
 
 const RECOIL_KEY = {
   candle: 'candleState',
+  favoriteCoinList: 'favoriteCoinListState',
+  selectedCoin: 'selectedCoinState',
 };
 
 export const candleState = atom<CandleType>({
@@ -11,12 +13,12 @@ export const candleState = atom<CandleType>({
 });
 
 export const favoriteCoinListState = atom<Market[]>({
-  key: 'favoriteCoinListState',
+  key: RECOIL_KEY.favoriteCoinList,
   default: [],
-  effects: [storageEffect('favoriteCoinListState', 'localStorage')],
+  effects: [storageEffect(RECOIL_KEY.favoriteCoinList, 'localStorage')],
 });
 
 export const selectedCoinState = atom<Market[]>({
-  key: 'selectedCoinState',
+  key: RECOIL_KEY.selectedCoin,
   default: [],
 });

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -1,10 +1,21 @@
 import {atom} from 'recoil';
+import {recoilPersist} from 'recoil-persist';
 
 const RECOIL_KEY = {
   candle: 'candleState',
 };
 
+const {persistAtom} = recoilPersist({
+  key: 'favoriteList',
+});
+
 export const candleState = atom<CandleType>({
   key: RECOIL_KEY.candle,
   default: 'minute',
+});
+
+export const favoriteList = atom({
+  key: 'favoriteList',
+  default: [],
+  effects_UNSTABLE: [persistAtom],
 });

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -1,4 +1,5 @@
-import {atom, AtomEffect} from 'recoil';
+import {atom} from 'recoil';
+import {storageEffect} from '@/effects';
 
 const RECOIL_KEY = {
   candle: 'candleState',
@@ -9,28 +10,8 @@ export const candleState = atom<CandleType>({
   default: 'minute',
 });
 
-function storageEffect<T = any>(
-  key: string,
-  storage: 'localStorage' | 'sessionStorage' = 'localStorage'
-): AtomEffect<T> {
-  if (typeof window === 'undefined') {
-    return () => {};
-  }
-
-  return ({setSelf, onSet}) => {
-    const savedData = localStorage.getItem('favoriteList');
-    if (savedData) setSelf(JSON.parse(savedData));
-
-    onSet((newValue, _, isReset) => {
-      isReset
-        ? localStorage.removeItem('favoriteList')
-        : localStorage.setItem('favoriteList', JSON.stringify(newValue));
-    });
-  };
-}
-
-export const favoriteList = atom<Market[]>({
-  key: 'favoriteList',
+export const favoriteListState = atom<Market[]>({
+  key: 'favoriteListState',
   default: [],
-  effects: [storageEffect('favoriteList')],
+  effects: [storageEffect('favoriteListState', 'localStorage')],
 });

--- a/src/atoms/index.ts
+++ b/src/atoms/index.ts
@@ -1,21 +1,36 @@
-import {atom} from 'recoil';
-import {recoilPersist} from 'recoil-persist';
+import {atom, AtomEffect} from 'recoil';
 
 const RECOIL_KEY = {
   candle: 'candleState',
 };
-
-const {persistAtom} = recoilPersist({
-  key: 'favoriteList',
-});
 
 export const candleState = atom<CandleType>({
   key: RECOIL_KEY.candle,
   default: 'minute',
 });
 
-export const favoriteList = atom({
+function storageEffect<T = any>(
+  key: string,
+  storage: 'localStorage' | 'sessionStorage' = 'localStorage'
+): AtomEffect<T> {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  return ({setSelf, onSet}) => {
+    const savedData = localStorage.getItem('favoriteList');
+    if (savedData) setSelf(JSON.parse(savedData));
+
+    onSet((newValue, _, isReset) => {
+      isReset
+        ? localStorage.removeItem('favoriteList')
+        : localStorage.setItem('favoriteList', JSON.stringify(newValue));
+    });
+  };
+}
+
+export const favoriteList = atom<Market[]>({
   key: 'favoriteList',
   default: [],
-  effects_UNSTABLE: [persistAtom],
+  effects: [storageEffect('favoriteList')],
 });

--- a/src/components/StockList/StockList.style.ts
+++ b/src/components/StockList/StockList.style.ts
@@ -9,19 +9,19 @@ export const FavoriteButton = styled.button`
   display: none;
 `;
 
-export const ToggleSwitch = styled.label<{onFavorite: boolean}>`
+export const ToggleSwitch = styled.label<{isFavorite: boolean}>`
   width: 40px;
   height: 20px;
   display: block;
   position: relative;
   border-radius: 30px;
-  background-color: ${props => (props.onFavorite ? 'gray' : props.theme.colors.BACKGROUND_MAIN)};
+  background-color: ${props => (props.isFavorite ? 'gray' : props.theme.colors.BACKGROUND_MAIN)};
   box-shadow: 0 0 16px 3px rgba(0 0 0 / 15%);
   cursor: pointer;
   transition: all 0.2s ease-in;
 `;
 
-export const ToggleButton = styled.span<{onFavorite: boolean}>`
+export const ToggleButton = styled.span<{isFavorite: boolean}>`
   width: 15px;
   height: 15px;
   position: absolute;
@@ -29,9 +29,9 @@ export const ToggleButton = styled.span<{onFavorite: boolean}>`
   left: 4px;
   transform: translateY(-50%);
   border-radius: 50%;
-  background: ${props => (props.onFavorite ? props.theme.colors.BACKGROUND_MAIN : 'gray')};
+  background: ${props => (props.isFavorite ? props.theme.colors.BACKGROUND_MAIN : 'gray')};
   ${props =>
-    props.onFavorite &&
+    props.isFavorite &&
     css`
       left: calc(100% - 20px);
     `}

--- a/src/components/StockList/StockList.style.ts
+++ b/src/components/StockList/StockList.style.ts
@@ -1,7 +1,41 @@
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 export const Wrapper = styled.div`
   flex: 1 1 auto;
+`;
+
+export const FavoriteButton = styled.button`
+  display: none;
+`;
+
+export const ToggleSwitch = styled.label<{onFavorite: boolean}>`
+  width: 40px;
+  height: 20px;
+  display: block;
+  position: relative;
+  border-radius: 30px;
+  background-color: ${props => (props.onFavorite ? 'gray' : props.theme.colors.BACKGROUND_MAIN)};
+  box-shadow: 0 0 16px 3px rgba(0 0 0 / 15%);
+  cursor: pointer;
+  transition: all 0.2s ease-in;
+`;
+
+export const ToggleButton = styled.span<{onFavorite: boolean}>`
+  width: 15px;
+  height: 15px;
+  position: absolute;
+  top: 50%;
+  left: 4px;
+  transform: translateY(-50%);
+  border-radius: 50%;
+  background: ${props => (props.onFavorite ? props.theme.colors.BACKGROUND_MAIN : 'gray')};
+  ${props =>
+    props.onFavorite &&
+    css`
+      left: calc(100% - 20px);
+    `}
+  transition: all 0.2s ease-in;
 `;
 
 export const BorderNone = styled.table`

--- a/src/components/StockList/StockList.style.ts
+++ b/src/components/StockList/StockList.style.ts
@@ -15,7 +15,8 @@ export const ToggleSwitch = styled.label<{isFavorite: boolean}>`
   display: block;
   position: relative;
   border-radius: 30px;
-  background-color: ${props => (props.isFavorite ? 'gray' : props.theme.colors.BACKGROUND_MAIN)};
+  background-color: ${props =>
+    props.isFavorite ? props.theme.colors.BACKGROUND_SUB : props.theme.colors.BACKGROUND_MAIN};
   box-shadow: 0 0 16px 3px rgba(0 0 0 / 15%);
   cursor: pointer;
   transition: all 0.2s ease-in;
@@ -29,7 +30,7 @@ export const ToggleButton = styled.span<{isFavorite: boolean}>`
   left: 4px;
   transform: translateY(-50%);
   border-radius: 50%;
-  background: ${props => (props.isFavorite ? props.theme.colors.BACKGROUND_MAIN : 'gray')};
+  background: ${props => (props.isFavorite ? props.theme.colors.BACKGROUND_MAIN : props.theme.colors.BACKGROUND_SUB)};
   ${props =>
     props.isFavorite &&
     css`
@@ -60,7 +61,8 @@ export const PrevButton = styled.button<{page: number; firstPage: number}>`
   margin: 0;
   border: 0;
   background-color: rgba(0, 0, 0, 0);
-  color: ${props => (props.page === props.firstPage ? 'gray' : 'black')};
+  color: ${props =>
+    props.page === props.firstPage ? props.theme.colors.BACKGROUND_SUB : props.theme.colors.FONT_MAIN};
   cursor: ${props => (props.page === props.firstPage ? 'default' : 'pointer')};
 `;
 
@@ -69,6 +71,6 @@ export const NextButton = styled.button<{page: number; lastPage: number}>`
   margin: 0;
   border: 0;
   background-color: rgba(0, 0, 0, 0);
-  color: ${props => (props.page === props.lastPage ? 'gray' : 'black')};
+  color: ${props => (props.page === props.lastPage ? props.theme.colors.BACKGROUND_SUB : props.theme.colors.FONT_MAIN)};
   cursor: ${props => (props.page === props.lastPage ? 'default' : 'pointer')};
 `;

--- a/src/components/StockList/StockList.tsx
+++ b/src/components/StockList/StockList.tsx
@@ -1,7 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 import {useState} from 'react';
 import {useRecoilValue} from 'recoil';
-import {favoriteList} from '@/atoms';
+import {favoriteListState} from '@/atoms';
 import {QUERY_KEYS} from '@/constants';
 import {getMarkets} from '@/http';
 import * as S from './StockList.style';
@@ -10,21 +10,21 @@ import StockListItem from './StockListItem';
 function StockList() {
   const [page, setPage] = useState<number>(0);
 
-  const [onFavorite, setOnFavorite] = useState<boolean>(false);
+  const [isFavorite, setIsFavorite] = useState<boolean>(false);
 
-  const favorites = useRecoilValue(favoriteList);
+  const favorites = useRecoilValue(favoriteListState);
 
-  const {data} = useQuery([QUERY_KEYS.markets], {
+  const {data: allCoinList} = useQuery([QUERY_KEYS.markets], {
     queryFn: () => getMarkets({queries: {isDetails: false}}),
     select: data => data.filter(market => market.market.includes('KRW')),
   });
 
-  if (!data) {
+  if (!allCoinList) {
     return <div>loading</div>;
   }
 
   const firstPage = 0;
-  const lastPage = Math.floor(data.length / 10);
+  const lastPage = Math.floor(allCoinList.length / 10);
 
   const prevPage = () => {
     if (page === firstPage) {
@@ -42,16 +42,14 @@ function StockList() {
     }
   };
 
-  const switchData = onFavorite ? favorites : data;
-
   return (
     <S.Wrapper>
-      <S.FavoriteButton id="toggle" onClick={() => setOnFavorite(!onFavorite)}></S.FavoriteButton>
-      <S.ToggleSwitch onFavorite={onFavorite} htmlFor="toggle">
-        <S.ToggleButton onFavorite={onFavorite} />
+      <S.FavoriteButton id="toggle" onClick={() => setIsFavorite(!isFavorite)}></S.FavoriteButton>
+      <S.ToggleSwitch isFavorite={isFavorite} htmlFor="toggle">
+        <S.ToggleButton isFavorite={isFavorite} />
       </S.ToggleSwitch>
       <S.BorderNone>
-        {switchData.slice(page * 10, (page + 1) * 10).map((market: Market) => (
+        {(isFavorite ? favorites : allCoinList).slice(page * 10, (page + 1) * 10).map((market: Market) => (
           <StockListItem ticker={market} key={market.market} />
         ))}
       </S.BorderNone>

--- a/src/components/StockList/StockList.tsx
+++ b/src/components/StockList/StockList.tsx
@@ -1,5 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 import {useState} from 'react';
+import {useRecoilValue} from 'recoil';
+import {favoriteList} from '@/atoms';
 import {QUERY_KEYS} from '@/constants';
 import {getMarkets} from '@/http';
 import * as S from './StockList.style';
@@ -7,6 +9,10 @@ import StockListItem from './StockListItem';
 
 function StockList() {
   const [page, setPage] = useState<number>(0);
+
+  const [onFavorite, setOnFavorite] = useState<boolean>(false);
+
+  const favorites = useRecoilValue(favoriteList);
 
   const {data} = useQuery([QUERY_KEYS.markets], {
     queryFn: () => getMarkets({queries: {isDetails: false}}),
@@ -36,10 +42,16 @@ function StockList() {
     }
   };
 
+  const switchData = onFavorite ? favorites : data;
+
   return (
     <S.Wrapper>
+      <S.FavoriteButton id="toggle" onClick={() => setOnFavorite(!onFavorite)}></S.FavoriteButton>
+      <S.ToggleSwitch onFavorite={onFavorite} htmlFor="toggle">
+        <S.ToggleButton onFavorite={onFavorite} />
+      </S.ToggleSwitch>
       <S.BorderNone>
-        {data.slice(page * 10, (page + 1) * 10).map(market => (
+        {switchData.slice(page * 10, (page + 1) * 10).map((market: Market) => (
           <StockListItem ticker={market} key={market.market} />
         ))}
       </S.BorderNone>

--- a/src/components/StockList/StockList.tsx
+++ b/src/components/StockList/StockList.tsx
@@ -1,7 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 import {useState} from 'react';
 import {useRecoilValue} from 'recoil';
-import {favoriteListState} from '@/atoms';
+import {favoriteCoinListState} from '@/atoms';
 import {QUERY_KEYS} from '@/constants';
 import {getMarkets} from '@/http';
 import * as S from './StockList.style';
@@ -12,7 +12,7 @@ function StockList() {
 
   const [isFavorite, setIsFavorite] = useState<boolean>(false);
 
-  const favorites = useRecoilValue(favoriteListState);
+  const favorites = useRecoilValue(favoriteCoinListState);
 
   const {data: allCoinList} = useQuery([QUERY_KEYS.markets], {
     queryFn: () => getMarkets({queries: {isDetails: false}}),

--- a/src/components/StockList/StockListItem.style.ts
+++ b/src/components/StockList/StockListItem.style.ts
@@ -1,16 +1,16 @@
 import styled from '@emotion/styled';
 
-export const StockListBody = styled.tbody`
+export const StockListBody = styled.tbody<{isTarget: boolean}>`
   height: 45px;
   width: 100%;
   vertical-align: middle;
-  background: #f8f9fa;
   &:hover,
   &:hover * {
     background: #f1f1f4;
   }
   border: 1px solid #dee2e6;
   border-collapse: collapse;
+  background: ${props => (props.isTarget ? '#f1f1f4' : '#f8f9fa')};
 `;
 
 export const Favorites = styled.button`
@@ -29,7 +29,6 @@ export const StockName = styled.td`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  background: #f8f9fa;
 `;
 
 export const StockPrice = styled.td<{fixedChangeRate: number}>`
@@ -38,7 +37,6 @@ export const StockPrice = styled.td<{fixedChangeRate: number}>`
   color: ${props => (props.fixedChangeRate > 0 ? 'red' : props.fixedChangeRate === 0 ? 'black' : 'blue')};
   font-size: 12px;
   white-space: nowrap;
-  background: #f8f9fa;
 `;
 
 export const StockChangeRate = styled.td<{fixedChangeRate: number}>`
@@ -47,7 +45,6 @@ export const StockChangeRate = styled.td<{fixedChangeRate: number}>`
   color: ${props => (props.fixedChangeRate > 0 ? 'red' : props.fixedChangeRate === 0 ? 'black' : 'blue')};
   font-size: 12px;
   white-space: nowrap;
-  background: #f8f9fa;
 `;
 
 export const StockAccTradePrice = styled.td`
@@ -56,5 +53,4 @@ export const StockAccTradePrice = styled.td`
   color: #333333;
   font-size: 12px;
   white-space: nowrap;
-  background: #f8f9fa;
 `;

--- a/src/components/StockList/StockListItem.style.ts
+++ b/src/components/StockList/StockListItem.style.ts
@@ -29,6 +29,10 @@ export const StockName = styled.td`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
 `;
 
 export const StockPrice = styled.td<{fixedChangeRate: number}>`
@@ -37,6 +41,7 @@ export const StockPrice = styled.td<{fixedChangeRate: number}>`
   color: ${props => (props.fixedChangeRate > 0 ? 'red' : props.fixedChangeRate === 0 ? 'black' : 'blue')};
   font-size: 12px;
   white-space: nowrap;
+  cursor: default;
 `;
 
 export const StockChangeRate = styled.td<{fixedChangeRate: number}>`
@@ -45,6 +50,7 @@ export const StockChangeRate = styled.td<{fixedChangeRate: number}>`
   color: ${props => (props.fixedChangeRate > 0 ? 'red' : props.fixedChangeRate === 0 ? 'black' : 'blue')};
   font-size: 12px;
   white-space: nowrap;
+  cursor: default;
 `;
 
 export const StockAccTradePrice = styled.td`
@@ -53,4 +59,5 @@ export const StockAccTradePrice = styled.td`
   color: #333333;
   font-size: 12px;
   white-space: nowrap;
+  cursor: default;
 `;

--- a/src/components/StockList/StockListItem.style.ts
+++ b/src/components/StockList/StockListItem.style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-export const StockListBody = styled.tbody<{isTarget: boolean}>`
+export const StockListBody = styled.tbody<{isSelected: boolean}>`
   height: 45px;
   width: 100%;
   vertical-align: middle;
@@ -8,9 +8,9 @@ export const StockListBody = styled.tbody<{isTarget: boolean}>`
   &:hover * {
     background: #f1f1f4;
   }
-  border: 1px solid #dee2e6;
+  border: 1px solid ${props => props.theme.colors.BORDER};
   border-collapse: collapse;
-  background: ${props => (props.isTarget ? '#f1f1f4' : '#f8f9fa')};
+  background: ${props => (props.isSelected ? '#f1f1f4' : '#f8f9fa')};
 `;
 
 export const Favorites = styled.button`
@@ -38,7 +38,12 @@ export const StockName = styled.td`
 export const StockPrice = styled.td<{fixedChangeRate: number}>`
   width: 40%;
   flex: 1;
-  color: ${props => (props.fixedChangeRate > 0 ? 'red' : props.fixedChangeRate === 0 ? 'black' : 'blue')};
+  color: ${props =>
+    props.fixedChangeRate > 0
+      ? props.theme.colors.RISE
+      : props.fixedChangeRate === 0
+      ? props.theme.colors.FONT_MAIN
+      : props.theme.colors.FALL};
   font-size: 12px;
   white-space: nowrap;
   cursor: default;
@@ -47,7 +52,12 @@ export const StockPrice = styled.td<{fixedChangeRate: number}>`
 export const StockChangeRate = styled.td<{fixedChangeRate: number}>`
   width: 50%;
   flex: 1;
-  color: ${props => (props.fixedChangeRate > 0 ? 'red' : props.fixedChangeRate === 0 ? 'black' : 'blue')};
+  color: ${props =>
+    props.fixedChangeRate > 0
+      ? props.theme.colors.RISE
+      : props.fixedChangeRate === 0
+      ? props.theme.colors.FONT_MAIN
+      : props.theme.colors.FALL};
   font-size: 12px;
   white-space: nowrap;
   cursor: default;

--- a/src/components/StockList/StockListItem.tsx
+++ b/src/components/StockList/StockListItem.tsx
@@ -1,7 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 import {useState} from 'react';
 import {useRecoilState} from 'recoil';
-import {favoriteListState} from '@/atoms';
+import {favoriteListState, targetState} from '@/atoms';
 import {getTicker} from '@/http';
 import * as S from './StockListItem.style';
 
@@ -11,6 +11,10 @@ function StockListItem({ticker}: StockListItemProp) {
   const [isFavorite, setIsFavorite] = useState<boolean>(favoriteState);
 
   const [favorites, setFavorites] = useRecoilState(favoriteListState);
+
+  const [target, setTarget] = useRecoilState(targetState);
+
+  const isTarget = target[0] === ticker ? true : false;
 
   const {data} = useQuery([ticker.market], {
     queryFn: () => getTicker({queries: {markets: ticker.market}}),
@@ -55,8 +59,13 @@ function StockListItem({ticker}: StockListItemProp) {
     });
   }
 
+  function onClick() {
+    const newTarget = [ticker];
+    setTarget(newTarget);
+  }
+
   return (
-    <S.StockListBody>
+    <S.StockListBody onClick={onClick} isTarget={isTarget}>
       <tr>
         <td rowSpan={2}>
           <S.Favorites onClick={toggleFavorite}>{isFavorite ? '★' : '☆'}</S.Favorites>

--- a/src/components/StockList/StockListItem.tsx
+++ b/src/components/StockList/StockListItem.tsx
@@ -1,20 +1,17 @@
 import {useQuery} from '@tanstack/react-query';
-import {useState} from 'react';
 import {useRecoilState} from 'recoil';
 import {favoriteCoinListState, selectedCoinState} from '@/atoms';
 import {getTicker} from '@/http';
 import * as S from './StockListItem.style';
 
 function StockListItem({ticker}: StockListItemProp) {
-  const favoriteState = JSON.parse(localStorage.getItem(`${ticker.market}`) ?? 'false');
-
-  const [isFavorite, setIsFavorite] = useState<boolean>(favoriteState);
-
   const [favorites, setFavorites] = useRecoilState(favoriteCoinListState);
 
   const [selectedCoin, setSelectedCoin] = useRecoilState(selectedCoinState);
 
   const isSelected = selectedCoin[0] === ticker ? true : false;
+
+  const isFavorite = favorites.includes(ticker);
 
   const {data} = useQuery([ticker.market], {
     queryFn: () => getTicker({queries: {markets: ticker.market}}),
@@ -43,20 +40,14 @@ function StockListItem({ticker}: StockListItemProp) {
   };
 
   function toggleFavorite() {
-    setIsFavorite(prev => {
-      if (prev) {
-        const newFavorites = [...favorites];
-        setFavorites(arrayRemove(newFavorites, ticker));
-        localStorage.setItem(ticker.market, (!prev).toString());
-        return !prev;
-      } else {
-        const newFavorites = [...favorites];
-        newFavorites.push(ticker);
-        setFavorites(newFavorites);
-        localStorage.setItem(ticker.market, (!prev).toString());
-        return !prev;
-      }
-    });
+    if (isFavorite) {
+      const newFavorites = [...favorites];
+      setFavorites(arrayRemove(newFavorites, ticker));
+    } else {
+      const newFavorites = [...favorites];
+      newFavorites.push(ticker);
+      setFavorites(newFavorites);
+    }
   }
 
   function onClick() {

--- a/src/components/StockList/StockListItem.tsx
+++ b/src/components/StockList/StockListItem.tsx
@@ -1,7 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 import {useState} from 'react';
 import {useRecoilState} from 'recoil';
-import {favoriteListState, targetState} from '@/atoms';
+import {favoriteCoinListState, selectedCoinState} from '@/atoms';
 import {getTicker} from '@/http';
 import * as S from './StockListItem.style';
 
@@ -10,11 +10,11 @@ function StockListItem({ticker}: StockListItemProp) {
 
   const [isFavorite, setIsFavorite] = useState<boolean>(favoriteState);
 
-  const [favorites, setFavorites] = useRecoilState(favoriteListState);
+  const [favorites, setFavorites] = useRecoilState(favoriteCoinListState);
 
-  const [target, setTarget] = useRecoilState(targetState);
+  const [selectedCoin, setSelectedCoin] = useRecoilState(selectedCoinState);
 
-  const isTarget = target[0] === ticker ? true : false;
+  const isSelected = selectedCoin[0] === ticker ? true : false;
 
   const {data} = useQuery([ticker.market], {
     queryFn: () => getTicker({queries: {markets: ticker.market}}),
@@ -60,12 +60,12 @@ function StockListItem({ticker}: StockListItemProp) {
   }
 
   function onClick() {
-    const newTarget = [ticker];
-    setTarget(newTarget);
+    const newSelectedCoin = [ticker];
+    setSelectedCoin(newSelectedCoin);
   }
 
   return (
-    <S.StockListBody onClick={onClick} isTarget={isTarget}>
+    <S.StockListBody onClick={onClick} isSelected={isSelected}>
       <tr>
         <td rowSpan={2}>
           <S.Favorites onClick={toggleFavorite}>{isFavorite ? '★' : '☆'}</S.Favorites>

--- a/src/components/StockList/StockListItem.tsx
+++ b/src/components/StockList/StockListItem.tsx
@@ -1,5 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 import {useState} from 'react';
+import {useRecoilState} from 'recoil';
+import {favoriteList} from '@/atoms';
 import {getTicker} from '@/http';
 import * as S from './StockListItem.style';
 
@@ -7,6 +9,8 @@ function StockListItem({ticker}: StockListItemProp) {
   const favoriteState = JSON.parse(localStorage.getItem(`${ticker.market}`) ?? 'false');
 
   const [isFavorite, setIsFavorite] = useState<boolean>(favoriteState);
+
+  const [favorites, setFavorites] = useRecoilState(favoriteList);
 
   const {data} = useQuery([ticker.market], {
     queryFn: () => getTicker({queries: {markets: ticker.market}}),
@@ -25,12 +29,29 @@ function StockListItem({ticker}: StockListItemProp) {
   }
 
   const fixedAccTradePrice = Math.floor(data[0].acc_trade_price_24h / 1000000);
+
   const fixedChangeRate = Math.round(data[0].signed_change_rate * 1000) / 1000;
+
+  const arrayRemove = (arr: any[], value: Market) => {
+    return arr.filter(ele => {
+      return ele != value;
+    });
+  };
 
   function toggleFavorite() {
     setIsFavorite(prev => {
-      localStorage.setItem(ticker.market, (!prev).toString());
-      return !prev;
+      if (prev) {
+        const newFavorites = [...favorites];
+        setFavorites(arrayRemove(newFavorites, ticker));
+        localStorage.setItem(ticker.market, (!prev).toString());
+        return !prev;
+      } else {
+        const newFavorites = [...favorites];
+        newFavorites.push(ticker);
+        setFavorites(newFavorites);
+        localStorage.setItem(ticker.market, (!prev).toString());
+        return !prev;
+      }
     });
   }
 

--- a/src/components/StockList/StockListItem.tsx
+++ b/src/components/StockList/StockListItem.tsx
@@ -1,7 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 import {useState} from 'react';
 import {useRecoilState} from 'recoil';
-import {favoriteList} from '@/atoms';
+import {favoriteListState} from '@/atoms';
 import {getTicker} from '@/http';
 import * as S from './StockListItem.style';
 
@@ -10,7 +10,7 @@ function StockListItem({ticker}: StockListItemProp) {
 
   const [isFavorite, setIsFavorite] = useState<boolean>(favoriteState);
 
-  const [favorites, setFavorites] = useRecoilState(favoriteList);
+  const [favorites, setFavorites] = useRecoilState(favoriteListState);
 
   const {data} = useQuery([ticker.market], {
     queryFn: () => getTicker({queries: {markets: ticker.market}}),

--- a/src/effects/index.ts
+++ b/src/effects/index.ts
@@ -1,0 +1,20 @@
+import {AtomEffect} from 'recoil';
+
+export function storageEffect<T = any>(
+  key: string,
+  type: 'localStorage' | 'sessionStorage' = 'localStorage'
+): AtomEffect<T> {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  return ({setSelf, onSet}) => {
+    const storage = type === 'localStorage' ? localStorage : sessionStorage;
+    const savedData = storage.getItem(key);
+    if (savedData) setSelf(JSON.parse(savedData));
+
+    onSet((newValue, _, isReset) => {
+      isReset ? storage.removeItem(key) : storage.setItem(key, JSON.stringify(newValue));
+    });
+  };
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2841,12 +2841,7 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
-recoil-persist@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/recoil-persist/-/recoil-persist-4.2.0.tgz#9fbb4a8c158cbb83ceb9dedf795aee24ed15395d"
-  integrity sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==
-
-recoil@^0.7.6:
+recoil@^0.7.7:
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"
   integrity sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2841,10 +2841,15 @@ react@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
+recoil-persist@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/recoil-persist/-/recoil-persist-4.2.0.tgz#9fbb4a8c158cbb83ceb9dedf795aee24ed15395d"
+  integrity sha512-MHVfML9GxJP3RpkKR4F5rp7DtvzIvjWhowtMao/b7h2k4afMio/4sMAdUtltIrDaeVegH0Iga8Sx5XQ3oD7CzA==
+
 recoil@^0.7.6:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.6.tgz#75297ecd70bbfeeb72e861aa6141a86bb6dfcd5e"
-  integrity sha512-hsBEw7jFdpBCY/tu2GweiyaqHKxVj6EqF2/SfrglbKvJHhpN57SANWvPW+gE90i3Awi+A5gssOd3u+vWlT+g7g==
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"
+  integrity sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==
   dependencies:
     hamt_plus "1.0.2"
 


### PR DESCRIPTION
1. 즐겨찾기 목록을 RecoilState를 이용해서 전역으로 상태저장했습니다. StockListItem 컴포넌트의 즐겨찾기 버튼을 누를 때 목록에 추가하고, 다시 누르면 목록에서 삭제됩니다. 저장된 목록을 StockList 컴포넌트에서 읽을 수 있게 했습니다.

2. StockList 컴포넌트에 즐겨찾기 토글버튼을 만들었습니다. 즐겨찾기로 전환하면 저장된 즐겨찾기 목록을 StockListItem컴포넌트에 전달하여 다시 렌더링합니다.

3. Recoil-Persist를 이용해 recoilState 상태를 저장했습니다. 해당 상태는 localstorage에 저장됩니다.  

4. 간단한 토글버튼 스타일링을 했습니다. 색상은 간단하게 일단 gray로 처리했습니다.
