### PR TITLE
refactor: market과 ticker를 합친 useCoinListQuery 훅 추가

### DIFF
--- a/src/constants/request.const.ts
+++ b/src/constants/request.const.ts
@@ -2,6 +2,7 @@ export const QUERY_KEYS = {
   ticker: 'ticker',
   markets: 'markets',
   candles: 'candles',
+  coinList: 'coinList',
 };
 
 export const MARKET_CODE = {

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -2,3 +2,4 @@ export {default as useMinuteCandleQuery} from './useMinuteCandleQuery';
 export {default as useDayCandleQuery} from './useDayCandleQuery';
 export {default as useWeekCandleQuery} from './useWeekCandleQuery';
 export {default as useMonthCandleQuery} from './useMonthCandleQuery';
+export {default as useCoinListQuery} from './useCoinListQuery';

--- a/src/hooks/queries/useCoinListQuery.ts
+++ b/src/hooks/queries/useCoinListQuery.ts
@@ -1,0 +1,17 @@
+import {useQuery} from '@tanstack/react-query';
+import {QUERY_KEYS} from '@/constants';
+import {getMarkets, getTicker} from '@/http';
+
+const useCoinListQuery = () => {
+  return useQuery<Coin[]>([QUERY_KEYS.coinList], {
+    initialData: [],
+    queryFn: async () => {
+      const markets = (await getMarkets({queries: {isDetails: false}})).filter(({market}) => market.includes('KRW'));
+      const tickers = await getTicker({queries: {markets: markets.map(({market}) => market).join(',')}});
+
+      return markets.map((market, idx) => ({...market, ...tickers[idx]}));
+    },
+  });
+};
+
+export default useCoinListQuery;

--- a/src/types/model.d.ts
+++ b/src/types/model.d.ts
@@ -46,3 +46,5 @@ interface Market {
   english_name: string;
   market_warning?: string;
 }
+
+type Coin = Ticker & Market;


### PR DESCRIPTION
`market`과 `ticker`를 합친 useCoinListQuery 훅을 추가하였습니다.

각 `ticker`를 따로 불러오던 부분도 이 훅으로 해결 가능할 것 같고, API 요청 제한으로 인한 요청 실패도 어느 정도 방지할 수 있을 것 같아요.

각자 작업한 영역에 코인 목록이 필요한 경우 기존에 사용하던 걸 이걸로 대체해서 사용해주세요~~